### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,17 +34,17 @@ jobs:
   
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
         with:
           submodules: recursive
 
       - name: Install .NET Core
-        uses: actions/setup-dotnet@v3.0.3
+        uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: 7
         
       - name: Setup NuGet.exe for use with actions
-        uses: NuGet/setup-nuget@v1.2.0
+        uses: NuGet/setup-nuget@v2.0.0
 
       - name: Set current version
         shell: pwsh
@@ -71,7 +71,7 @@ jobs:
           Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.3.1
         with:
           path: ./Agent/bin/Remotely-MacOS-x64.zip
           name: Mac-Agent-x64
@@ -92,7 +92,7 @@ jobs:
     steps:
        
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4.1.1
       with:
         # Comment out the below 'repository' line if you want to build from
         # your fork instead of the author's.
@@ -102,13 +102,13 @@ jobs:
         
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v3.0.3
+      uses: actions/setup-dotnet@v4.0.0
       with:
         dotnet-version: 7
       
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     # Execute all unit tests in the solution
     - name: Execute unit tests
@@ -148,7 +148,7 @@ jobs:
         
         
     - name: Download macOS x64 Agent
-      uses: actions/download-artifact@v2.1.1
+      uses: actions/download-artifact@v4.1.2
       with:
         name: Mac-Agent-x64
         path: ./Server/wwwroot/Content/
@@ -161,7 +161,7 @@ jobs:
         
     # Upload build artifact to be deployed from Ubuntu runner
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@v4.3.1
       with:
         path: ./publish/
         name: Server

--- a/.github/workflows/dockerarm64.yml
+++ b/.github/workflows/dockerarm64.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.1.1
           
       - name: Log in to Github
         uses: docker/login-action@v3.0.0
@@ -20,7 +20,7 @@ jobs:
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.0.0
+        uses: docker/metadata-action@v5.5.1
         with:
           images: |
            ghcr.io/${{ github.repository }}
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v5.1.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: ./Server

--- a/.github/workflows/githubaction.yml
+++ b/.github/workflows/githubaction.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GIT_TOKEN}}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,20 +25,20 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v4.1.1
       with:
         submodules: recursive
         fetch-depth: 0
 
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v3.0.3
+      uses: actions/setup-dotnet@v4.0.0
       with:
         dotnet-version: 7
       
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     # Execute all unit tests in the solution
     - name: Execute unit tests


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[microsoft/setup-msbuild](https://github.com/microsoft/setup-msbuild)** published a new release **[v2](https://github.com/microsoft/setup-msbuild/releases/tag/v2)** on 2024-01-31T01:06:10Z
* **[NuGet/setup-nuget](https://github.com/NuGet/setup-nuget)** published a new release **[v2.0.0](https://github.com/NuGet/setup-nuget/releases/tag/v2.0.0)** on 2024-01-30T21:34:31Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.2](https://github.com/actions/download-artifact/releases/tag/v4.1.2)** on 2024-02-05T21:28:08Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.5.1](https://github.com/docker/metadata-action/releases/tag/v5.5.1)** on 2024-01-31T13:07:55Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.1.0](https://github.com/docker/build-push-action/releases/tag/v5.1.0)** on 2023-11-17T12:46:31Z
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.0.0](https://github.com/actions/setup-dotnet/releases/tag/v4.0.0)** on 2023-12-04T14:24:07Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.1](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)** on 2024-02-05T21:40:25Z
